### PR TITLE
Cf zone settings ssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ code_kaizen.cloudflare.hello_world|Returns Hello message.
 ### Modules
 Name | Description
 --- | ---
-[code_kaizen.cloudflare.cfd_tunnel](http://example.com/repository/blob/main/docs/code_kaizen.cloudflare.cfd_tunnel_module.rst)|Manage Cloudflare Tunnel
+[code_kaizen.cloudflare.cfd_tunnel](https://github.com/codekaizen-github/cloudflare-ansible-collection/blob/main/docs/code_kaizen.cloudflare.cfd_tunnel_module.rst)|Manage Cloudflare Tunnel
 
 <!--end collection content-->
 

--- a/docs/code_kaizen.cloudflare.cfd_tunnel_module.rst
+++ b/docs/code_kaizen.cloudflare.cfd_tunnel_module.rst
@@ -1,0 +1,241 @@
+.. _code_kaizen.cloudflare.cfd_tunnel_module:
+
+
+*********************************
+code_kaizen.cloudflare.cfd_tunnel
+*********************************
+
+**Manage Cloudflare Tunnel**
+
+
+Version added: 0.0.1
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Manages Cloudflare Tunnel
+
+
+
+Requirements
+------------
+The below requirements are needed on the host that executes this module.
+
+- requests>=2.22.0
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+            <th width="100%">Comments</th>
+        </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>account_id</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 0.0.1</div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>ID of the Cloudflare account.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>api_token</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 0.0.1</div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The Cloudflare API token.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>config_src</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 0.0.1</div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>local</b>&nbsp;&larr;</div></li>
+                                    <li>cloudflare</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Indicates if this is a locally or remotely configured tunnel.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 0.0.1</div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>A user-friendly name for a tunnel.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 0.0.1</div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>absent</li>
+                                    <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                    <li>fetched</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Whether the tunnel should exist or not.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>tunnel_secret</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 0.0.1</div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Sets the password required to run a locally-managed tunnel. Must be at least 32 bytes and encoded as a base64 string.</div>
+                </td>
+            </tr>
+    </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - N/A
+
+
+See Also
+--------
+
+.. seealso::
+
+   `Cloudflare Tunnels API reference <https://developers.cloudflare.com/api/operations/cloudflare-tunnel-create-a-cloudflare-tunnel>`_
+       Complete reference of the Cloudflare Tunnels API.
+
+
+Examples
+--------
+
+.. code-block:: yaml
+
+    - name: Add or update a Cloudflare Tunnel
+      code_kaizen.cloudflare.cfd_tunnel:
+        api_token: mytoken
+        account_id: 12345
+        name: my-tunnel
+        config_src: cloudflare
+        tunnel_secret: "AQIDBAUGBwgBAgMEBQYHCAECAwQFBgcIAQIDBAUGBwg="
+        state: present
+      register: results
+
+    - name: Delete a Cloudflare Tunnel
+      code_kaizen.cloudflare.cfd_tunnel:
+        api_token: mytoken
+        account_id: 12345
+        name: my-tunnel
+        state: absent
+      register: results
+
+    - name: Fetch a Cloudflare Tunnel
+      code_kaizen.cloudflare.cfd_tunnel:
+        api_token: mytoken
+        account_id: 12345
+        name: my-tunnel
+        state: fetched
+      register: results
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>variable</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                    </div>
+                </td>
+                <td>success and O(state=present)</td>
+                <td>
+                            <div>A list of Cloudflare Tunnels as JSON. See <a href='https://developers.cloudflare.com/api/operations/cloudflare-tunnel-list-cloudflare-tunnels'>https://developers.cloudflare.com/api/operations/cloudflare-tunnel-list-cloudflare-tunnels</a>.</div>
+                    <br/>
+                </td>
+            </tr>
+    </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Andrew Dawes (@andrewjdawes)

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.14.0"
+requires_ansible: ">=2.15.0"

--- a/plugins/modules/cloudflare_zone_settings_ssl.py
+++ b/plugins/modules/cloudflare_zone_settings_ssl.py
@@ -1,0 +1,119 @@
+#!/usr/bin/python
+
+import json
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.urls import fetch_url
+
+
+def fetch_ssl_settings(module, api_token, zone):
+    url = f"https://api.cloudflare.com/client/v4/zones?name={zone}"
+    headers = {
+        "Authorization": f"Bearer {api_token}",
+        "Content-Type": "application/json",
+    }
+
+    response, info = fetch_url(module, url, headers=headers, method="GET")
+    if info["status"] != 200:
+        module.fail_json(
+            msg="Failed to fetch zone information",
+            details=info,
+        )
+
+    result = json.loads(response.read())
+    zone_id = result["result"][0]["id"]
+
+    url = f"https://api.cloudflare.com/client/v4/zones/{zone_id}/settings/ssl"
+    response, info = fetch_url(module, url, headers=headers, method="GET")
+    if info["status"] != 200:
+        module.fail_json(
+            msg="Failed to fetch SSL settings",
+            details=info,
+        )
+
+    result = json.loads(response.read())
+    return result["result"]
+
+
+def set_ssl_settings(module, api_token, zone, value):
+    url = f"https://api.cloudflare.com/client/v4/zones?name={zone}"
+    headers = {
+        "Authorization": f"Bearer {api_token}",
+        "Content-Type": "application/json",
+    }
+
+    response, info = fetch_url(module, url, headers=headers, method="GET")
+    if info["status"] != 200:
+        module.fail_json(
+            msg="Failed to fetch zone information",
+            details=info,
+        )
+
+    result = json.loads(response.read())
+    zone_id = result["result"][0]["id"]
+
+    url = f"https://api.cloudflare.com/client/v4/zones/{zone_id}/settings/ssl"
+    data = json.dumps({"value": value})
+    response, info = fetch_url(
+        module,
+        url,
+        data=data,
+        headers=headers,
+        method="PATCH",
+    )
+    if info["status"] != 200:
+        module.fail_json(
+            msg="Failed to set SSL settings",
+            details=info,
+        )
+
+    result = json.loads(response.read())
+    return result["result"]
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            zone=dict(type="str", required=True),
+            api_token=dict(type="str", required=True, no_log=True),
+            state=dict(
+                type="str",
+                choices=["fetched", "present"],
+                required=True,
+            ),
+            value=dict(
+                type="str",
+                choices=["full", "flexible", "strict", "off"],
+                required=False,
+            ),
+        ),
+        supports_check_mode=True,
+    )
+
+    zone = module.params["zone"]
+    api_token = module.params["api_token"]
+    state = module.params["state"]
+    value = module.params.get("value")
+
+    if state == "fetched":
+        result = fetch_ssl_settings(module, api_token, zone)
+        module.exit_json(
+            changed=False,
+            ssl_settings=result,
+            message="SSL settings fetched successfully.",
+        )
+    elif state == "present":
+        if not value:
+            module.fail_json(
+                msg="Value parameter is required when state is 'present'",
+            )
+        result = set_ssl_settings(module, api_token, zone, value)
+        module.exit_json(
+            changed=True,
+            ssl_settings=result,
+            message="SSL settings updated successfully.",
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/cloudflare_zone_settings_ssl/tasks/main.yml
+++ b/tests/integration/targets/cloudflare_zone_settings_ssl/tasks/main.yml
@@ -1,0 +1,47 @@
+---
+- name: Fetch SSL settings
+  cloudflare_zone_settings_ssl:
+    zone: "sandbox.com"
+    api_token: "A3veZ5sTB5Wt-TmAV6oK53F7zVin4vecIuux8Wyy"
+    state: fetched
+  register: fetch_result
+
+- name: Debug fetch_result
+  ansible.builtin.debug:
+    var: fetch_result
+
+- name: Set SSL settings to 'off'
+  cloudflare_zone_settings_ssl:
+    zone: "your-zone-name"
+    api_token: "your-api-token"
+    state: present
+    value: "off"
+  register: set_result
+
+- name: Set SSL settings to 'flexible'
+  cloudflare_zone_settings_ssl:
+    zone: "your-zone-name"
+    api_token: "your-api-token"
+    state: present
+    value: "flexible"
+  register: set_result
+
+- name: Set SSL settings to 'full'
+  cloudflare_zone_settings_ssl:
+    zone: "your-zone-name"
+    api_token: "your-api-token"
+    state: present
+    value: "full"
+  register: set_result
+
+- name: Set SSL settings to 'strict'
+  cloudflare_zone_settings_ssl:
+    zone: "your-zone-name"
+    api_token: "your-api-token"
+    state: present
+    value: "strict"
+  register: set_result
+
+- name: Debug set_result
+  ansible.builtin.debug:
+    var: set_result

--- a/tests/integration/targets/cloudflare_zone_settings_ssl/tasks/main.yml
+++ b/tests/integration/targets/cloudflare_zone_settings_ssl/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 - name: Fetch SSL settings
   cloudflare_zone_settings_ssl:
-    zone: "sandbox.com"
-    api_token: "A3veZ5sTB5Wt-TmAV6oK53F7zVin4vecIuux8Wyy"
+    zone: "your-zone-name"
+    api_token: "your-api-token"
     state: fetched
   register: fetch_result
 


### PR DESCRIPTION
This adds the cloudflare_zone_settings_ssl.py module. This allows users to manage Cloudflare SSL settings for a zone. You can use it to fetch the current settings or to set the SSL setting to either off, full, strict, or flexible. This branch also includes an example playbook for managing Cloudflare SSL settings.

